### PR TITLE
support for pip pkgs

### DIFF
--- a/build/build.rb
+++ b/build/build.rb
@@ -45,7 +45,7 @@ Dir.glob("#{ENV['CROWBAR_DIR']}/barclamps/*/crowbar.yml").each do |yml|
   FileUtils.mkdir_p(pip_cache_path)
   data["pips"].each do |pip_n|
     repeat_unless 2, "failed download pip #{pip_n}" do
-      system "pip2tgz tmp_cache_path \"#{pip_n}\""
+      system "pip2tgz \"#{tmp_cache_path}\" \"#{pip_n}\""
     end
   end
   system "cp -a #{tmp_cache_path}/. #{pip_cache_path}"


### PR DESCRIPTION
since we have mechanism to proved additional dependencies for pfs we need a mechanism to pull that dependencies into crowbar cache, there it is
now we may define at crowbar.yml something like
pips:
- anyjson
- nose
- httplib2>=0.7.0
- testtools>=0.9.29
