### PR TITLE
Fix ntp smoke test and small git-barclamp deprication [1/2]

### DIFF
--- a/crowbar_framework/app/views/barclamp/git/_pfsdeps.html.haml
+++ b/crowbar_framework/app/views/barclamp/git/_pfsdeps.html.haml
@@ -18,7 +18,7 @@
     = select_tag :use_pip_cache, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["use_pip_cache"].to_s), :onchange => "update_value('use_pip_cache', 'use_pip_cache', 'boolean')"
   %p
     %label{ :for => :git_instance }= t('.git_instance')
-    = instance_selector("git", :git_instance, "git_instance", @proposal)
+    = render_instance_selector("git", :git_instance, t('.git_instance'), "git_instance", @proposal)
   %p
     %label{ :for => :deps }= t('.deps')
     %textarea{ :id => "pfs_deps", :onchange => "update_deps()"}


### PR DESCRIPTION
Fix ntp smoke test pattern match 

Fix small git-barclamp issue that spews deprecation msgs into log.

 .../app/views/barclamp/git/_pfsdeps.html.haml      |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: f93ee6da089135b5255053486ada9c325839b955

Crowbar-Release: pebbles
