### PR TITLE
Add options for explicit behavior of pip utility

### DIFF
--- a/build/build.rb
+++ b/build/build.rb
@@ -83,7 +83,7 @@ begin
   pip_requires.each do |pip|
      current_pip = pip
      puts ">>> Try download pip: #{current_pip}"
-     system("pip install --quiet --download #{pip_cache_path} \"#{current_pip}\"")
+     system("pip install --quiet --download #{pip_cache_path} --no-use-wheel --no-compile \"#{current_pip}\"")
   end
 
   #build simple path


### PR DESCRIPTION
Exclude the possibility of unpredictable behavior on some build environment when pip utility downloads whl package type.
