### PR TITLE
Replaced gitignore file with content as in all other barclamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-chef/cookbooks/git/attributes/default.rb
+.DS_Store
+*~
+
+.coverage/
+rubydeps.*

--- a/gitignore
+++ b/gitignore
@@ -1,5 +1,0 @@
-.DS_Store
-*~
-
-.coverage/
-rubydeps.*


### PR DESCRIPTION
I renamed the gitignore within
https://github.com/tboerger/barclamp-git/commit/7ffc9d91df8441b46b863e2ba4fd0a310f354122 wrong. Simply renamed it to .gitignore
now.
